### PR TITLE
Add poetry module

### DIFF
--- a/synth_a_py/__init__.py
+++ b/synth_a_py/__init__.py
@@ -1,10 +1,12 @@
 __version__ = "1.6.0"
 
-from .base import Dir, File, Project
+from .base import Dir, File, Project, auto_synth
 from .file import EmptyFile, SimpleFile
 from .gitignore import GitIgnore
 from .ini import IniFile
-from .license import License
+from .license import License, LicenseBase
+from .poetry import PoetryModule
+from .tokens import Managed
 from .toml import TomlFile
 from .yaml import YamlFile
 
@@ -15,8 +17,13 @@ __all__ = [
     "GitIgnore",
     "IniFile",
     "License",
+    "LicenseBase",
+    "Managed",
+    "Poetry",
     "Project",
+    "PoetryModule",
     "SimpleFile",
     "TomlFile",
     "YamlFile",
+    "auto_synth",
 ]

--- a/synth_a_py/base.py
+++ b/synth_a_py/base.py
@@ -1,110 +1,80 @@
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from contextvars import ContextVar, Token
 from pathlib import Path
 from types import TracebackType
-from typing import TYPE_CHECKING, Callable, Dict, Iterator, Optional, Tuple, Type, Union
+from typing import Callable, Dict, Iterator, Optional, Tuple, Type, Union
 
 from returns.functions import compose
 
-from .utils import init_mix_ins
-
 __all__ = [
-    "File",
     "Project",
     "Dir",
+    "File",
 ]
+
+
+__container_context: "ContextVar[Optional[Container]]" = ContextVar(
+    "__container_context", default=None
+)
+
+
+def _context_get() -> "Container":
+    container = __container_context.get()
+    assert container is not None
+    return container
+
+
+def _context_set_root(
+    value: "Container",
+) -> "Token[Optional[Container]]":
+    container = __container_context.get()
+    assert container is None
+    return __container_context.set(value)
+
+
+def _context_set(value: "Container") -> "Token[Optional[Container]]":
+    container = __container_context.get()
+    assert container is not None
+    return __container_context.set(value)
+
+
+def _context_reset(token: "Token[Optional[Container]]") -> None:
+    container = __container_context.get()
+    assert container is not None
+    __container_context.reset(token)
 
 
 PathResolver = Callable[[Path], Path]
 
 
-class _FileContainerMixIn:
+class Container(ABC):
     def __init__(self) -> None:
-        self.__store: Dict[str, Union[File, Dir]] = dict()
+        self._store: "Dict[str, Union[File, Dir]]" = dict()
+        self._context_token: "Optional[Token[Optional[Container]]]" = None
 
     def add(self, item: Union["File", "Dir"]) -> None:
-        assert item.name not in self.__store
-        self.__store[item.name] = item
+        assert item.name not in self._store
+        self._store[item.name] = item
 
     def walk(self) -> Iterator[Tuple[PathResolver, "File"]]:
         item: Union[File, Dir]
-        for item in self.__store.values():
+        for item in self._store.values():
 
             def path_resolver(path: Path) -> Path:
                 return path / item.name
 
-            if isinstance(item, File):
-                yield path_resolver, item
-            else:
+            if isinstance(item, Container):
                 for subpath_resolver, subitem in item.walk():
                     yield compose(path_resolver, subpath_resolver), subitem
+            else:
+                yield path_resolver, item
 
     def subpaths(self) -> Iterator[str]:
         return (str(path_resolver(Path("."))) for path_resolver, _ in self.walk())
 
-
-if TYPE_CHECKING:
-    _ContextToken = Token[Optional[_FileContainerMixIn]]
-else:
-    _ContextToken = Token
-
-__context: ContextVar[Optional[_FileContainerMixIn]] = ContextVar(
-    "__context", default=None
-)
-
-
-def _context_get() -> _FileContainerMixIn:
-    project = __context.get()
-    assert project is not None
-    return project
-
-
-def _context_set_root(value: _FileContainerMixIn) -> _ContextToken:
-    project = __context.get()
-    assert project is None
-    return __context.set(value)
-
-
-def _context_set(value: _FileContainerMixIn) -> _ContextToken:
-    project = __context.get()
-    assert project is not None
-    return __context.set(value)
-
-
-def _context_reset(token: _ContextToken) -> None:
-    project = __context.get()
-    assert project is not None
-    __context.reset(token)
-
-
-class _ChildMixIn:
-    def __init__(self) -> None:
-        self.parent = _context_get()
-        assert isinstance(self, File) or isinstance(self, Dir)
-        self.parent.add(self)
-
-
-class File(_ChildMixIn):
-    def __init__(self, name: str) -> None:
-        self.name = name
-        init_mix_ins(self, File)
-
-    @abstractmethod
-    def synth_content(self) -> str:
-        ...
-
-
-class _ContextMixIn(_FileContainerMixIn):
-    def __init__(self) -> None:
-        self.__context_token: Optional[_ContextToken] = None
-        init_mix_ins(self, _ContextMixIn)
-
     def __enter__(self) -> None:
-        assert self.__context_token is None
-        if isinstance(self, Project):
-            self.__context_token = _context_set_root(self)
-        else:
-            self.__context_token = _context_set(self)
+        assert self._context_token is None
+        self._context_token = _context_set(self)
 
     def __exit__(
         self,
@@ -112,12 +82,16 @@ class _ContextMixIn(_FileContainerMixIn):
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> None:
-        assert self.__context_token is not None
-        _context_reset(self.__context_token)
-        self.__context_token = None
+        assert self._context_token is not None
+        _context_reset(self._context_token)
+        self._context_token = None
 
 
-class Project(_ContextMixIn):
+class Project(Container):
+    def __enter__(self) -> None:
+        assert self._context_token is None
+        self._context_token = _context_set_root(self)
+
     def synth(self, root: Optional[Path] = None) -> None:
         if root is None:
             root = Path.cwd()
@@ -138,7 +112,19 @@ class Project(_ContextMixIn):
             path.chmod(0o444)
 
 
-class Dir(_ContextMixIn, _ChildMixIn):
+class Dir(Container):
+    def __init__(self, name: str) -> None:
+        super().__init__()
+        self.name = name
+        _context_get().add(self)
+
+
+class File:
     def __init__(self, name: str) -> None:
         self.name = name
-        init_mix_ins(self, Dir)
+        self.parent = _context_get()
+        self.parent.add(self)
+
+    @abstractmethod
+    def synth_content(self) -> str:
+        ...

--- a/synth_a_py/license.py
+++ b/synth_a_py/license.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from textwrap import dedent
 from typing import Type
 
@@ -5,17 +6,20 @@ from typing_extensions import Literal
 
 from .base import File
 
-__all__ = ["License"]
+__all__ = [
+    "LicenseBase",
+    "License",
+]
 
 
-class _License(File):
+class LicenseBase(File, ABC):
     def __init__(self, copyright_period: str, copyright_holders: str):
         super().__init__("LICENSE")
         self.copyright_period = copyright_period
         self.copyright_holders = copyright_holders
 
 
-class _ApacheLicense(_License):
+class _ApacheLicense(LicenseBase):
     def __init__(
         self, version: Literal["2.0"], copyright_period: str, copyright_holders: str
     ) -> None:
@@ -227,7 +231,7 @@ class _ApacheLicense(_License):
 """  # noqa: E501
 
 
-class _MITLicense(_License):
+class _MITLicense(LicenseBase):
     def synth_content(self) -> str:
         return dedent(
             f"""\

--- a/synth_a_py/poetry/__init__.py
+++ b/synth_a_py/poetry/__init__.py
@@ -1,0 +1,108 @@
+from typing import Any, Dict, List, Optional, cast
+
+from synth_a_py.base import Dir
+from synth_a_py.poetry.versions import (
+    DependencyDict,
+    ManagableDependencyDict,
+    ManagableVersion,
+    Managed,
+    Version,
+    VersionSpec,
+)
+from synth_a_py.toml import TomlFile
+
+__all__ = [
+    "PoetryModule",
+]
+
+
+def resolve_dependencies(
+    managable_dependencies: ManagableDependencyDict,
+    dependency_management: DependencyDict,
+) -> DependencyDict:
+    if not dependency_management:
+        return cast(DependencyDict, managable_dependencies)
+
+    def get_managed_version(dep: str) -> Version:
+        try:
+            return dependency_management[dep]
+        except Exception as e:
+            raise Exception(f"Dependency {dep} missing from dependency_management", e)
+
+    def resolve_dependency(dep: str, version: ManagableVersion) -> Version:
+        if isinstance(version, str):
+            return version
+        elif version == Managed:
+            return get_managed_version(dep)
+        elif isinstance(version, dict) and version["version"] == Managed:
+            managed_version = get_managed_version(dep)
+            resolved_version: VersionSpec = {
+                "version": managed_version
+                if isinstance(managed_version, str)
+                else managed_version["version"]
+            }
+
+            if "extras" in version:
+                resolved_version["extras"] = version["extras"]
+
+            return resolved_version
+        else:
+            return cast(VersionSpec, version)
+
+    return {
+        dep: resolve_dependency(dep, version)
+        for dep, version in managable_dependencies.items()
+    }
+
+
+class PoetryModule:
+    def __init__(
+        self,
+        *,
+        name: str,
+        description: str,
+        version: str,
+        authors: Optional[List[str]] = None,
+        license: Optional[str] = None,
+        dependencies: Optional[ManagableDependencyDict] = None,
+        dev_dependencies: Optional[ManagableDependencyDict] = None,
+        dependency_management: Optional[DependencyDict] = None,
+    ):
+        self.dir = Dir(name)
+        with self.dir:
+            pyproject_tool_poetry: Dict[str, Any] = {
+                "name": name,
+                "description": description,
+                "version": version,
+                "authors": authors or [],
+            }
+
+            if license:
+                pyproject_tool_poetry["license"] = license
+
+            dependency_management = dependency_management or {}
+
+            if dependencies:
+                pyproject_tool_poetry["dependencies"] = resolve_dependencies(
+                    dependencies,
+                    dependency_management,
+                )
+
+            if dev_dependencies:
+                pyproject_tool_poetry["dev-dependencies"] = resolve_dependencies(
+                    dev_dependencies,
+                    dependency_management,
+                )
+
+            self.pyproject = TomlFile(
+                "pyproject.toml",
+                {
+                    "build-system": {
+                        "requires": ["poetry-core>=1.0.0"],
+                        "build-backend": "poetry.core.masonry.api",
+                    },
+                    "tool": {
+                        "poetry": pyproject_tool_poetry,
+                    },
+                },
+            )

--- a/synth_a_py/poetry/versions.py
+++ b/synth_a_py/poetry/versions.py
@@ -1,4 +1,6 @@
-from typing import Dict, List, Type, TypedDict, Union
+from typing import Dict, List, Type, Union
+
+from typing_extensions import TypedDict
 
 __all__ = [
     "ManagableDependencyDict",

--- a/synth_a_py/poetry/versions.py
+++ b/synth_a_py/poetry/versions.py
@@ -1,0 +1,56 @@
+from typing import Dict, List, Type, TypedDict, Union
+
+__all__ = [
+    "ManagableDependencyDict",
+    "DependencyDict",
+    "ManagableVersion",
+    "Managed",
+    "Version",
+    "VersionSpec",
+]
+
+
+class VersionSpecBase(TypedDict):
+    version: str
+
+
+class VersionSpec(VersionSpecBase, total=False):
+    extras: List[str]
+
+
+Version = Union[
+    str,
+    VersionSpec,
+]
+
+
+DependencyDict = Dict[
+    str,
+    Version,
+]
+
+
+class Managed:
+    def __init__(self) -> None:
+        raise Exception("Do not instanitate")
+
+
+class ManagableVersionSpecBase(TypedDict):
+    version: Union[str, Type[Managed]]
+
+
+class ManagableVersionSpec(ManagableVersionSpecBase, total=False):
+    extras: List[str]
+
+
+ManagableVersion = Union[
+    str,
+    ManagableVersionSpec,
+    Type[Managed],
+]
+
+
+ManagableDependencyDict = Dict[
+    str,
+    ManagableVersion,
+]

--- a/synth_a_py/tokens.py
+++ b/synth_a_py/tokens.py
@@ -1,0 +1,7 @@
+__all__ = [
+    "Managed",
+]
+
+
+class Managed:
+    pass

--- a/synth_a_py/utils.py
+++ b/synth_a_py/utils.py
@@ -2,16 +2,6 @@ __all__ = [
     "ensure_nl",
 ]
 
-from inspect import Parameter, Signature
-
-from typing_extensions import Final
-
 
 def ensure_nl(s: str) -> str:
     return s.rstrip() + "\n"
-
-
-no_param_init: Final[Signature] = Signature(
-    (Parameter("self", Parameter.POSITIONAL_OR_KEYWORD),),
-    return_annotation=None,
-)

--- a/synth_a_py/utils.py
+++ b/synth_a_py/utils.py
@@ -1,10 +1,8 @@
 __all__ = [
     "ensure_nl",
-    "init_mix_ins",
 ]
 
-from inspect import Parameter, Signature, signature
-from typing import Any
+from inspect import Parameter, Signature
 
 from typing_extensions import Final
 
@@ -17,11 +15,3 @@ no_param_init: Final[Signature] = Signature(
     (Parameter("self", Parameter.POSITIONAL_OR_KEYWORD),),
     return_annotation=None,
 )
-
-
-def init_mix_ins(self: Any, t: type) -> None:
-    bases = t.__bases__
-    for base in bases:
-        init = getattr(base, "__init__")
-        if signature(init) == no_param_init:
-            init(self)

--- a/tests/test_poetry_module.py
+++ b/tests/test_poetry_module.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from textwrap import dedent
-from typing import List, TypedDict
+from typing import List
+
+from typing_extensions import TypedDict
 
 from synth_a_py import Dir, PoetryModule, auto_synth
 from synth_a_py.poetry.versions import DependencyDict, Managed

--- a/tests/test_poetry_module.py
+++ b/tests/test_poetry_module.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+from textwrap import dedent
+
+from synth_a_py import Dir, PoetryModule, auto_synth
+from synth_a_py.poetry.versions import Managed
+
+
+def test_python_module_poetry(tmp_path: Path) -> None:
+    with auto_synth(tmp_path):
+        common_metadata = {
+            "version": "1.0.0",
+            "authors": ["Joseph Egan <...>"],
+            "license": "MIT",
+            "dependency_management": {
+                "pandas": "1.2.0",
+            },
+        }
+
+        common_dependencies = {
+            "python": "^3.8",
+        }
+
+        common_dev_dependencies = {
+            "pytest": "^5",
+        }
+
+        PoetryModule(
+            name="deployment",
+            description="Code to deploy lambdas",
+            **common_metadata,  # type: ignore
+            dependencies={},
+            dev_dependencies={
+                **common_dev_dependencies,
+            },
+        )
+
+        with Dir("lambdas"):
+            PoetryModule(
+                name="alpha",
+                description="Alpha lambda",
+                **common_metadata,  # type: ignore
+                dependencies={
+                    **common_dependencies,
+                    "dep42": {
+                        "version": "1.0.0",
+                        "extras": ["blue", "green"],
+                    },
+                },
+                dev_dependencies={
+                    **common_dev_dependencies,
+                },
+            )
+
+            PoetryModule(
+                name="beta",
+                description="Beta lambda",
+                **common_metadata,  # type: ignore
+                dependencies={
+                    **common_dependencies,
+                    "dep42": {
+                        "version": "1.0.0",
+                        "extras": ["blue", "green"],
+                    },
+                    "pandas": Managed,
+                },
+                dev_dependencies={
+                    **common_dev_dependencies,
+                },
+            )
+
+    file_path = tmp_path / "file"
+    assert file_path.stat().st_mode & 0o777 == 0o444
+    assert file_path.read_text() == dedent(
+        """\
+        Lorem ipsum dolor sit amet
+        consectetur adipiscing elit
+        Cras eros purus
+        aliquet ac magna ut
+        fermentum cursus turpis
+        """
+    )

--- a/tests/test_poetry_module.py
+++ b/tests/test_poetry_module.py
@@ -1,13 +1,22 @@
 from pathlib import Path
 from textwrap import dedent
+from typing import List, TypedDict
 
 from synth_a_py import Dir, PoetryModule, auto_synth
-from synth_a_py.poetry.versions import Managed
+from synth_a_py.poetry.versions import DependencyDict, Managed
+
+
+# allows mypy to correctly type check `**` statements
+class CommonMetadata(TypedDict):
+    version: str
+    authors: List[str]
+    license: str
+    dependency_management: DependencyDict
 
 
 def test_python_module_poetry(tmp_path: Path) -> None:
     with auto_synth(tmp_path):
-        common_metadata = {
+        common_metadata: CommonMetadata = {
             "version": "1.0.0",
             "authors": ["Joseph Egan <...>"],
             "license": "MIT",
@@ -27,7 +36,7 @@ def test_python_module_poetry(tmp_path: Path) -> None:
         PoetryModule(
             name="deployment",
             description="Code to deploy lambdas",
-            **common_metadata,  # type: ignore
+            **common_metadata,
             dependencies={},
             dev_dependencies={
                 **common_dev_dependencies,
@@ -38,7 +47,7 @@ def test_python_module_poetry(tmp_path: Path) -> None:
             PoetryModule(
                 name="alpha",
                 description="Alpha lambda",
-                **common_metadata,  # type: ignore
+                **common_metadata,
                 dependencies={
                     **common_dependencies,
                     "dep42": {
@@ -54,7 +63,7 @@ def test_python_module_poetry(tmp_path: Path) -> None:
             PoetryModule(
                 name="beta",
                 description="Beta lambda",
-                **common_metadata,  # type: ignore
+                **common_metadata,
                 dependencies={
                     **common_dependencies,
                     "dep42": {
@@ -68,14 +77,71 @@ def test_python_module_poetry(tmp_path: Path) -> None:
                 },
             )
 
-    file_path = tmp_path / "file"
-    assert file_path.stat().st_mode & 0o777 == 0o444
-    assert file_path.read_text() == dedent(
+    assert (tmp_path / "deployment" / "pyproject.toml").read_text() == dedent(
         """\
-        Lorem ipsum dolor sit amet
-        consectetur adipiscing elit
-        Cras eros purus
-        aliquet ac magna ut
-        fermentum cursus turpis
+        [build-system]
+        requires = [ "poetry-core>=1.0.0",]
+        build-backend = "poetry.core.masonry.api"
+
+        [tool.poetry]
+        name = "deployment"
+        description = "Code to deploy lambdas"
+        version = "1.0.0"
+        authors = [ "Joseph Egan <...>",]
+        license = "MIT"
+
+        [tool.poetry.dev-dependencies]
+        pytest = "^5"
+        """
+    )
+
+    assert (tmp_path / "lambdas" / "alpha" / "pyproject.toml").read_text() == dedent(
+        """\
+        [build-system]
+        requires = [ "poetry-core>=1.0.0",]
+        build-backend = "poetry.core.masonry.api"
+
+        [tool.poetry]
+        name = "alpha"
+        description = "Alpha lambda"
+        version = "1.0.0"
+        authors = [ "Joseph Egan <...>",]
+        license = "MIT"
+
+        [tool.poetry.dependencies]
+        python = "^3.8"
+
+        [tool.poetry.dev-dependencies]
+        pytest = "^5"
+
+        [tool.poetry.dependencies.dep42]
+        version = "1.0.0"
+        extras = [ "blue", "green",]
+        """
+    )
+
+    assert (tmp_path / "lambdas" / "beta" / "pyproject.toml").read_text() == dedent(
+        """\
+        [build-system]
+        requires = [ "poetry-core>=1.0.0",]
+        build-backend = "poetry.core.masonry.api"
+
+        [tool.poetry]
+        name = "beta"
+        description = "Beta lambda"
+        version = "1.0.0"
+        authors = [ "Joseph Egan <...>",]
+        license = "MIT"
+
+        [tool.poetry.dependencies]
+        python = "^3.8"
+        pandas = "1.2.0"
+
+        [tool.poetry.dev-dependencies]
+        pytest = "^5"
+
+        [tool.poetry.dependencies.dep42]
+        version = "1.0.0"
+        extras = [ "blue", "green",]
         """
     )


### PR DESCRIPTION
Add a high level class for creating poetry modules and contains a refactor of the base module... probably needs to be split out into multiple PRs

Ignoring the refactor

Features
- Creates directory and `pyproject.toml` within it
- Facilitates (crude?) dependency management

Todos
- [ ] `poetry.toml`
- [ ] more tests?

Probably needs a bit more thinking time in it's current state